### PR TITLE
Do not trigger activeadmin setup inside initializer

### DIFF
--- a/lib/active_admin/audit/engine.rb
+++ b/lib/active_admin/audit/engine.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
           include ActiveAdmin::VersionsHelper
         end
 
-        ActiveAdmin.setup do |config|
+        ActiveAdmin.before_load do |config|
           config.before_filter :set_paper_trail_whodunnit
         end
       end


### PR DESCRIPTION
`ActiveAdmin.setup` triggers a lot and should be called as late as possible - in application initializers.